### PR TITLE
Removed sys.stdout.write

### DIFF
--- a/teardrops/td.py
+++ b/teardrops/td.py
@@ -104,7 +104,6 @@ def __Zone(board, points, track):
     for p in points:
         ol.Append(p.x, p.y)
 
-    sys.stdout.write("+")
     return z
 
 


### PR DESCRIPTION
The call for `sys.stdout.write` prevents the plugin from working.
The reason is most likely that KiBuzzard changed its way of logging: 

https://github.com/gregdavill/KiBuzzard/commit/8bf3db0e7950d92f59178c18e60e7bb816d5173f

The teardrops messages ended up in KiBuzzards logfile which was not intended I guess.

To me the message lokks like a development artifact which can be removed anyway.