### PR TITLE
Fix zone initialisation

### DIFF
--- a/teardrops/td.py
+++ b/teardrops/td.py
@@ -9,7 +9,7 @@
 from math import cos, sin, asin, atan2, sqrt, pi
 from pcbnew import PCB_VIA, ToMM, PCB_TRACK, FromMM, wxPoint, GetBoard, ZONE
 from pcbnew import PAD_ATTRIB_PTH, PAD_ATTRIB_SMD, ZONE_FILLER, VECTOR2I
-from pcbnew import STARTPOINT, ENDPOINT, ZONE_SETTINGS, ZONE_CONNECTION_FULL
+from pcbnew import STARTPOINT, ENDPOINT, ZONE_SETTINGS, ZONE_CONNECTION_FULL, ZONE_FILL_MODE_POLYGONS
 
 __version__ = "0.5.0"
 
@@ -94,6 +94,7 @@ def __Zone(board, points, track):
     z.SetMinThickness(25400)  # The minimum
     z.SetPadConnection(ZONE_CONNECTION_FULL)
     z.SetCornerSmoothingType(ZONE_SETTINGS.SMOOTHING_NONE)
+    z.SetFillMode(ZONE_FILL_MODE_POLYGONS)
     z.SetIsFilled(True)
     z.SetPriority(MAGIC_TEARDROP_ZONE_ID)
     ol = z.Outline()

--- a/teardrops/td.py
+++ b/teardrops/td.py
@@ -9,7 +9,7 @@
 from math import cos, sin, asin, atan2, sqrt, pi
 from pcbnew import PCB_VIA, ToMM, PCB_TRACK, FromMM, wxPoint, GetBoard, ZONE
 from pcbnew import PAD_ATTRIB_PTH, PAD_ATTRIB_SMD, ZONE_FILLER, VECTOR2I
-from pcbnew import STARTPOINT, ENDPOINT
+from pcbnew import STARTPOINT, ENDPOINT, ZONE_SETTINGS, ZONE_CONNECTION_FULL
 
 __version__ = "0.5.0"
 
@@ -92,7 +92,8 @@ def __Zone(board, points, track):
     z.SetNetCode(track.GetNetCode())
     z.SetLocalClearance(track.GetLocalClearance(track.GetClass()))
     z.SetMinThickness(25400)  # The minimum
-    z.SetPadConnection(2)  # 2 -> solid
+    z.SetPadConnection(ZONE_CONNECTION_FULL)
+    z.SetCornerSmoothingType(ZONE_SETTINGS.SMOOTHING_NONE)
     z.SetIsFilled(True)
     z.SetPriority(MAGIC_TEARDROP_ZONE_ID)
     ol = z.Outline()


### PR DESCRIPTION
It appears that the default settings for new zones are whatever values were last manually set. This can result in incorrect zone configuration for teardrops.

Steps to reproduce:
1. Open a board with no teardrops and at least one other filled zone.
2. Edit the filled zone to have hatched fill and 0.5mm corner fillet
3. Use the teardrop action plugin to add teardrops
4. Observe that created teardrops erroneously have the hatched fill and 0.5mm corner fillet setting

This was observed on KiCAD 6.0.0 release.