### PR TITLE
Support arc tracks

### DIFF
--- a/teardrops/td.py
+++ b/teardrops/td.py
@@ -229,7 +229,7 @@ def __ComputePoints(track, via, hpercent, vpercent, segs, follow_tracks,
         vpercent = 100
 
     # ensure that start is at the via/pad end
-    if __PointDistance(end, via[0]) < radius:
+    if __PointDistance(start, via[0]) > radius:
         start, end = end, start
         trackReversed = True
 

--- a/teardrops/teardrop.fbp
+++ b/teardrops/teardrop.fbp
@@ -45,7 +45,7 @@
             <property name="minimum_size"></property>
             <property name="name">teardrop_gui</property>
             <property name="pos"></property>
-            <property name="size">450,368</property>
+            <property name="size">450,415</property>
             <property name="style">wxCAPTION|wxCLOSE_BOX|wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER</property>
             <property name="subclass">; ; forward_declare</property>
             <property name="title">Teardrops</property>

--- a/teardrops/teardrop.fbp
+++ b/teardrops/teardrop.fbp
@@ -45,7 +45,7 @@
             <property name="minimum_size"></property>
             <property name="name">teardrop_gui</property>
             <property name="pos"></property>
-            <property name="size">450,415</property>
+            <property name="size">450,368</property>
             <property name="style">wxCAPTION|wxCLOSE_BOX|wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER</property>
             <property name="subclass">; ; forward_declare</property>
             <property name="title">Teardrops</property>
@@ -147,7 +147,7 @@
                                 <property name="vgap">0</property>
                                 <object class="sizeritem" expanded="0">
                                     <property name="border">5</property>
-                                    <property name="flag">wxALIGN_CENTER|wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxEXPAND|wxFIXED_MINSIZE</property>
+                                    <property name="flag">wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxFIXED_MINSIZE</property>
                                     <property name="proportion">0</property>
                                     <object class="wxStaticText" expanded="0">
                                         <property name="BottomDockable">1</property>
@@ -270,7 +270,7 @@
                                 </object>
                                 <object class="sizeritem" expanded="0">
                                     <property name="border">5</property>
-                                    <property name="flag">wxALIGN_CENTER|wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxEXPAND|wxFIXED_MINSIZE</property>
+                                    <property name="flag">wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxFIXED_MINSIZE</property>
                                     <property name="proportion">0</property>
                                     <object class="wxStaticText" expanded="0">
                                         <property name="BottomDockable">1</property>
@@ -393,7 +393,7 @@
                                 </object>
                                 <object class="sizeritem" expanded="0">
                                     <property name="border">5</property>
-                                    <property name="flag">wxALIGN_CENTER|wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxEXPAND|wxFIXED_MINSIZE</property>
+                                    <property name="flag">wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxFIXED_MINSIZE</property>
                                     <property name="proportion">0</property>
                                     <object class="wxStaticText" expanded="0">
                                         <property name="BottomDockable">1</property>
@@ -518,7 +518,7 @@
                         </object>
                         <object class="sizeritem" expanded="0">
                             <property name="border">5</property>
-                            <property name="flag">wxALIGN_CENTER|wxALIGN_CENTER_VERTICAL|wxALIGN_LEFT|wxALL</property>
+                            <property name="flag">wxALIGN_CENTER_VERTICAL|wxALIGN_LEFT|wxALL</property>
                             <property name="proportion">0</property>
                             <object class="wxStaticBitmap" expanded="0">
                                 <property name="BottomDockable">0</property>
@@ -597,7 +597,7 @@
                         <property name="permission">none</property>
                         <object class="sizeritem" expanded="0">
                             <property name="border">5</property>
-                            <property name="flag">wxALIGN_CENTER_VERTICAL|wxALIGN_LEFT|wxALL|wxEXPAND</property>
+                            <property name="flag">wxALIGN_LEFT|wxALL|wxEXPAND</property>
                             <property name="proportion">0</property>
                             <object class="wxCheckBox" expanded="0">
                                 <property name="BottomDockable">1</property>
@@ -661,7 +661,7 @@
                         </object>
                         <object class="sizeritem" expanded="0">
                             <property name="border">5</property>
-                            <property name="flag">wxALIGN_CENTER_VERTICAL|wxALIGN_LEFT|wxALL|wxEXPAND</property>
+                            <property name="flag">wxALIGN_LEFT|wxALL|wxEXPAND</property>
                             <property name="proportion">0</property>
                             <object class="wxCheckBox" expanded="0">
                                 <property name="BottomDockable">1</property>
@@ -725,7 +725,7 @@
                         </object>
                         <object class="sizeritem" expanded="0">
                             <property name="border">5</property>
-                            <property name="flag">wxALIGN_CENTER_VERTICAL|wxALIGN_LEFT|wxALL|wxEXPAND</property>
+                            <property name="flag">wxALIGN_LEFT|wxALL|wxEXPAND</property>
                             <property name="proportion">0</property>
                             <object class="wxCheckBox" expanded="0">
                                 <property name="BottomDockable">1</property>
@@ -789,7 +789,7 @@
                         </object>
                         <object class="sizeritem" expanded="0">
                             <property name="border">5</property>
-                            <property name="flag">wxALIGN_CENTER_VERTICAL|wxALIGN_LEFT|wxALL|wxEXPAND</property>
+                            <property name="flag">wxALIGN_LEFT|wxALL|wxEXPAND</property>
                             <property name="proportion">0</property>
                             <object class="wxCheckBox" expanded="0">
                                 <property name="BottomDockable">1</property>

--- a/teardrops/teardrop_gui.py
+++ b/teardrops/teardrop_gui.py
@@ -17,7 +17,7 @@ import wx.xrc
 class teardrop_gui ( wx.Dialog ):
 
 	def __init__( self, parent ):
-		wx.Dialog.__init__ ( self, parent, id = wx.ID_ANY, title = u"Teardrops", pos = wx.DefaultPosition, size = wx.Size( 450,415 ), style = wx.CAPTION|wx.CLOSE_BOX|wx.DEFAULT_DIALOG_STYLE|wx.RESIZE_BORDER )
+		wx.Dialog.__init__ ( self, parent, id = wx.ID_ANY, title = u"Teardrops", pos = wx.DefaultPosition, size = wx.Size( 450,368 ), style = wx.CAPTION|wx.CLOSE_BOX|wx.DEFAULT_DIALOG_STYLE|wx.RESIZE_BORDER )
 
 		#self.SetSizeHints( wx.DefaultSize, wx.DefaultSize )
 		import sys
@@ -40,32 +40,32 @@ class teardrop_gui ( wx.Dialog ):
 		self.st_hpercent = wx.StaticText( self, wx.ID_ANY, u"Horizontal percent", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.st_hpercent.Wrap( -1 )
 
-		gs_params.Add( self.st_hpercent, 0, wx.ALIGN_CENTER|wx.ALIGN_CENTER_VERTICAL|wx.ALIGN_RIGHT|wx.EXPAND|wx.FIXED_MINSIZE, 5 )
+		gs_params.Add( self.st_hpercent, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALIGN_RIGHT|wx.FIXED_MINSIZE, 5 )
 
-		self.sp_hpercent = wx.SpinCtrl( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS, 0, 100, 50 )
-		gs_params.Add( self.sp_hpercent, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALIGN_RIGHT|wx.EXPAND|wx.FIXED_MINSIZE|wx.SHAPED, 5 )
+		self.sp_hpercent = wx.SpinCtrl( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.Size( 100,25 ), wx.SP_ARROW_KEYS, 0, 100, 50 )
+		gs_params.Add( self.sp_hpercent, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALIGN_RIGHT|wx.FIXED_MINSIZE|wx.SHAPED, 5 )
 
 		self.st_vpercent = wx.StaticText( self, wx.ID_ANY, u"Vertical percent", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.st_vpercent.Wrap( -1 )
 
-		gs_params.Add( self.st_vpercent, 0, wx.ALIGN_CENTER|wx.ALIGN_CENTER_VERTICAL|wx.ALIGN_RIGHT|wx.EXPAND|wx.FIXED_MINSIZE, 5 )
+		gs_params.Add( self.st_vpercent, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALIGN_RIGHT|wx.FIXED_MINSIZE, 5 )
 
-		self.sp_vpercent = wx.SpinCtrl( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS, 0, 100, 90 )
-		gs_params.Add( self.sp_vpercent, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALIGN_RIGHT|wx.EXPAND|wx.FIXED_MINSIZE|wx.SHAPED, 5 )
+		self.sp_vpercent = wx.SpinCtrl( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.Size( 100,25 ), wx.SP_ARROW_KEYS, 0, 100, 90 )
+		gs_params.Add( self.sp_vpercent, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALIGN_RIGHT|wx.FIXED_MINSIZE|wx.SHAPED, 5 )
 
 		self.st_nbseg = wx.StaticText( self, wx.ID_ANY, u"Number of segments", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.st_nbseg.Wrap( -1 )
 
-		gs_params.Add( self.st_nbseg, 0, wx.ALIGN_CENTER|wx.ALIGN_CENTER_VERTICAL|wx.ALIGN_RIGHT|wx.EXPAND|wx.FIXED_MINSIZE, 5 )
+		gs_params.Add( self.st_nbseg, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALIGN_RIGHT|wx.FIXED_MINSIZE, 5 )
 
-		self.sp_nbseg = wx.SpinCtrl( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS, 2, 100, 10 )
-		gs_params.Add( self.sp_nbseg, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALIGN_RIGHT|wx.EXPAND|wx.FIXED_MINSIZE|wx.SHAPED, 5 )
+		self.sp_nbseg = wx.SpinCtrl( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.Size( 100,25 ), wx.SP_ARROW_KEYS, 2, 100, 10 )
+		gs_params.Add( self.sp_nbseg, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALIGN_RIGHT|wx.FIXED_MINSIZE|wx.SHAPED, 5 )
 
 
 		bhs_params.Add( gs_params, 1, wx.ALIGN_CENTER_VERTICAL|wx.EXPAND|wx.SHAPED, 5 )
 
 		self.m_bitmap_help = wx.StaticBitmap( self, wx.ID_ANY, wx.NullBitmap, wx.DefaultPosition, wx.DefaultSize, 0 )
-		bhs_params.Add( self.m_bitmap_help, 0, wx.ALIGN_CENTER|wx.ALIGN_CENTER_VERTICAL|wx.ALIGN_LEFT|wx.ALL, 5 )
+		bhs_params.Add( self.m_bitmap_help, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALIGN_LEFT|wx.ALL, 5 )
 
 
 		bhs_params.Add( ( 0, 0), 1, wx.EXPAND, 5 )
@@ -76,19 +76,19 @@ class teardrop_gui ( wx.Dialog ):
 		bvs_options = wx.BoxSizer( wx.VERTICAL )
 
 		self.cb_include_smd_pads = wx.CheckBox( self, wx.ID_ANY, u"Include SMD pads", wx.DefaultPosition, wx.DefaultSize, 0 )
-		bvs_options.Add( self.cb_include_smd_pads, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALIGN_LEFT|wx.ALL|wx.EXPAND, 5 )
+		bvs_options.Add( self.cb_include_smd_pads, 0, wx.ALIGN_LEFT|wx.ALL|wx.EXPAND, 5 )
 
 		self.cb_discard_in_same_zone = wx.CheckBox( self, wx.ID_ANY, u"Do not insert teardrop inside same net zones", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.cb_discard_in_same_zone.SetValue(True)
-		bvs_options.Add( self.cb_discard_in_same_zone, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALIGN_LEFT|wx.ALL|wx.EXPAND, 5 )
+		bvs_options.Add( self.cb_discard_in_same_zone, 0, wx.ALIGN_LEFT|wx.ALL|wx.EXPAND, 5 )
 
 		self.cb_follow_tracks = wx.CheckBox( self, wx.ID_ANY, u"Follow tracks if shorter than needed", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.cb_follow_tracks.SetValue(True)
-		bvs_options.Add( self.cb_follow_tracks, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALIGN_LEFT|wx.ALL|wx.EXPAND, 5 )
+		bvs_options.Add( self.cb_follow_tracks, 0, wx.ALIGN_LEFT|wx.ALL|wx.EXPAND, 5 )
 
 		self.cb_no_bulge = wx.CheckBox( self, wx.ID_ANY, u"Prevent eccentric teardrops from bulging outwards", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.cb_no_bulge.SetValue(True)
-		bvs_options.Add( self.cb_no_bulge, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALIGN_LEFT|wx.ALL|wx.EXPAND, 5 )
+		bvs_options.Add( self.cb_no_bulge, 0, wx.ALIGN_LEFT|wx.ALL|wx.EXPAND, 5 )
 
 		bvs_options.Add( ( 0, 0), 1, wx.EXPAND, 5 )
 

--- a/teardrops/teardrop_gui.py
+++ b/teardrops/teardrop_gui.py
@@ -17,7 +17,7 @@ import wx.xrc
 class teardrop_gui ( wx.Dialog ):
 
 	def __init__( self, parent ):
-		wx.Dialog.__init__ ( self, parent, id = wx.ID_ANY, title = u"Teardrops", pos = wx.DefaultPosition, size = wx.Size( 450,368 ), style = wx.CAPTION|wx.CLOSE_BOX|wx.DEFAULT_DIALOG_STYLE|wx.RESIZE_BORDER )
+		wx.Dialog.__init__ ( self, parent, id = wx.ID_ANY, title = u"Teardrops", pos = wx.DefaultPosition, size = wx.Size( 450,415 ), style = wx.CAPTION|wx.CLOSE_BOX|wx.DEFAULT_DIALOG_STYLE|wx.RESIZE_BORDER )
 
 		#self.SetSizeHints( wx.DefaultSize, wx.DefaultSize )
 		import sys


### PR DESCRIPTION
I've added basic support for kicad 6's arc tracks, works with both an arc directly to the pad and with follow-tracks enabled.

![image](https://user-images.githubusercontent.com/19376076/151384427-c00b4051-3393-4cda-880d-98484f23084a.png)

It's not perfect, really the intersection between pad and arc should be calculated properly instead of taking a guess, but this is definitely good enough for most use cases.

This was committed onto the end of the V5.99_V6RC branch.