### PR TITLE
add packaging script + ci

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,16 @@
+name: package
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  package:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: ./package.sh
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: package.zip
+          tag_name: latest

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "https://go.kicad.org/pcm/schemas/v1",
+    "name": "Teardrops",
+    "description": "Manages teardrops on a PCB",
+    "description_full": "Manages teardrops on a PCB",
+    "identifier": "com.github.NilujePerchut.kicad-scripts-teardrops",
+    "type": "plugin",
+    "author": {
+        "name": "NilujePerchut",
+        "contact": {
+            "web": "https://github.com/NilujePerchut"
+        }
+    },
+    "maintainer": {
+        "name": "NilujePerchut",
+        "contact": {
+            "web": "https://github.com/NilujePerchut"
+        }
+    },
+    "license": "BSD-3-Clause",
+    "resources": {
+        "homepage": "https://github.com/NilujePerchut/kicad_scripts"
+    },
+    "versions": [
+        {
+            "version": "1.0",
+            "status": "testing",
+            "kicad_version": "6.0"
+        }
+    ]
+}

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+mkdir package
+mkdir package/plugins
+cp -r teardrops/* package/plugins
+mkdir package/resources
+cp teardrops/teardrops.png package/resources/icon.png
+cp metadata.json package
+cd package
+zip -r ../package.zip .
+cd ..


### PR DESCRIPTION
Hi!
This adds minimal support for a installation-workflow of
* click "download" on the "latest" release
* use the "install from file" function in the plugin and content manager

This should also provide some foundation for implementing #38, if desired (i guess the teardrops feature from 6.99 will make it into a release at some point?)

See https://github.com/ottojo/kicad_teardrops/releases/tag/latest for how this would look